### PR TITLE
fix incompatibility with MW REL1_39

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,13 @@ LocalSettings.php.
 `$wgAutoCreatePageMaxRecursion`: The maximum recursion depth to which calls of
 `createpageifnotex` are executed on created pages. Default: 1.
 
+`$wgAutoCreatePageIgnoreEmptyContent`: If invocations of `createpageifnotex`
+should silently ignore missing page content. Default: false (will put an error
+message on the wiki page).
+
 `$wgAutoCreatePageIgnoreEmptyTitle`: If invocations of `createpageifnotex`
-should be silently ignored. Default: false (will put an error message on the
-wiki page).
+should silently ignore missing page title. Default: false (will put an error
+message on the wiki page).
 
 `$wgAutoCreatePageNamespaces`: The list of namespaces in which calls of
 `createpageifnotex` are executed. If your call originates from a page not in

--- a/extension.json
+++ b/extension.json
@@ -32,6 +32,9 @@
 		"AutoCreatePageIgnoreEmptyTitle": {
 			"value": false
 		},
+		"AutoCreatePageIgnoreEmptyContent": {
+			"value": false
+		},
 		"AutoCreatePageMaxRecursion": {
 			"value": 1
 		},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -4,5 +4,10 @@
 			"Universal Omega"
 		]
 	},
-	"autocreatepage-desc": "Provides a parser function to create additional wiki pages with default content when saving a page."
+	"autocreatepage-desc": "Provides a parser function to create additional wiki pages with default content when saving a page.",
+	"autocreatepage-error-empty-content": "Error: For a page to be created, page content must be provided.",
+	"autocreatepage-error-empty-title": "Error: this function must be given a valid title text for the page to be created. $1",
+	"autocreatepage-error-missing-hook-parameter": "Hook invoked with missing parameters.",
+	"autocreatepage-error-recursion-level-exceeded": "Error: Recursion level for auto-created pages exceeded.",
+	"autocreatepage-revision-comment": "Page created automatically by parser function on page [[$1]]"
 }


### PR DESCRIPTION
WikiPage:doEditContent has been removed, page update is being refactored.

Please check out

  https://github.com/wikimedia/mediawiki/blob/master/docs/pageupdater.md

This commit modifies AutoCreatePageHooks::onRevisionDataUpdates to take care of these changes.

Fixes #8 